### PR TITLE
Show the error when failed fetch data

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils'
 import { Inter } from 'next/font/google'
 import { StrictMode } from 'react'
 import './globals.css'
+import { Toaster } from '@/components/ui/sonner'
 
 const inter = Inter({
   subsets: ['latin'],
@@ -36,6 +37,7 @@ export default function RootLayout({
             disableTransitionOnChange
           >
             {children}
+            <Toaster />
           </ThemeProvider>
         </body>
       </html>

--- a/components/combobox-area.tsx
+++ b/components/combobox-area.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { Areas as BaseAreas, GetArea, Query, getData } from '@/lib/data'
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { Combobox, ComboboxProps } from './combobox'
+import { ucFirstStr } from '@/lib/utils'
+
+type Areas = Exclude<BaseAreas, 'islands'>
+
+export type ComboboxAreaProps<A extends Areas> = Omit<
+  ComboboxProps<GetArea<A>>,
+  'autoClose' | 'fullWidth' | 'getOptionLabel' | 'options' | 'optionKey'
+> & {
+  area: A
+  query?: Query<A>
+}
+
+const singletonArea: { [A in Areas]: string } = {
+  provinces: 'province',
+  regencies: 'regency',
+  districts: 'district',
+  villages: 'village',
+}
+
+export default function ComboboxArea<A extends Areas>({
+  area,
+  query,
+  ...comboboxProps
+}: ComboboxAreaProps<A>) {
+  const [options, setOptions] = useState<GetArea<A>[]>([])
+
+  useEffect(() => {
+    getData(area, { ...query, sortBy: 'name' })
+      .then((res) => {
+        if ('data' in res) return setOptions(res.data)
+        throw new Error(res.message[0])
+      })
+      .catch((err) => {
+        toast.error(`Failed to fetch ${singletonArea[area]} data`, {
+          description: err.message,
+          closeButton: true,
+        })
+      })
+  }, [area, query])
+
+  return (
+    // @ts-expect-error
+    <Combobox
+      {...comboboxProps}
+      options={options}
+      optionKey="code"
+      getOptionLabel={(opt: { name: string }) => opt.name}
+      label={comboboxProps.label || ucFirstStr(singletonArea[area])}
+      placeholder={
+        comboboxProps.placeholder || `Search ${ucFirstStr(singletonArea[area])}`
+      }
+      autoClose
+      fullWidth
+    />
+  )
+}

--- a/components/map-dashboard.tsx
+++ b/components/map-dashboard.tsx
@@ -24,7 +24,7 @@ import {
 } from './ui/resizable'
 import { Skeleton } from './ui/skeleton'
 import { debounce } from '@/lib/utils'
-import { toast } from 'sonner'
+import ComboboxArea from './combobox-area'
 
 const Map = dynamic(() => import('@/components/map'), {
   loading: () => <Skeleton className="h-full rounded-none" />,
@@ -49,97 +49,21 @@ type Selected = {
   village?: Village
 }
 
-function ComboboxArea<T extends { code: string; name: string }>(
-  props: Omit<
-    ComboboxProps<T>,
-    'autoClose' | 'fullWidth' | 'optionKey' | 'getOptionLabel'
-  >,
-) {
-  return (
-    <Combobox
-      {...(props as ComboboxProps<T>)}
-      optionKey="code"
-      getOptionLabel={(opt) => opt.name}
-      autoClose
-      fullWidth
-    />
-  )
-}
-
 const MAX_PAGE_SIZE = config.dataSource.pagination.maxPageSize
 
+const provinceQuery: Query<'provinces'> = {
+  limit: MAX_PAGE_SIZE,
+}
+
 export default function MapDashboard() {
-  const [provinces, setProvinces] = useState<Province[]>([])
-  const [regencies, setRegencies] = useState<Regency[]>([])
   const [islands, setIslands] = useState<Island[]>([])
-  const [districts, setDistricts] = useState<District[]>([])
-  const [villages, setVillages] = useState<Village[]>([])
   const [selected, setSelected] = useState<Selected>()
-  const [query, setQuery] = useState<{ [A in Areas]?: Query<A> }>()
+  const [query, setQuery] =
+    useState<{ [A in Exclude<Areas, 'provinces'>]?: Query<A> }>()
   const [loadingIslands, setLoadingIslands] = useState<boolean>(false)
   const [panelDirection, setPanelDirection] = useState<
     'horizontal' | 'vertical'
   >('horizontal')
-
-  // Province data
-  useEffect(() => {
-    getData('provinces', { sortBy: 'name', limit: MAX_PAGE_SIZE })
-      .then((res) => {
-        if ('data' in res) return setProvinces(res.data)
-        throw new Error(res.message[0])
-      })
-      .catch((err) => {
-        toast.error('Failed to fetch province data', {
-          description: err.message,
-          closeButton: true,
-        })
-      })
-  }, [])
-
-  // Regency data
-  useEffect(() => {
-    getData('regencies', { ...query?.regencies, sortBy: 'name' })
-      .then((res) => {
-        if ('data' in res) return setRegencies(res.data)
-        throw new Error(res.message[0])
-      })
-      .catch((err) => {
-        toast.error('Failed to fetch regency data', {
-          description: err.message,
-          closeButton: true,
-        })
-      })
-  }, [query?.regencies])
-
-  // District data
-  useEffect(() => {
-    getData('districts', { ...query?.districts, sortBy: 'name' })
-      .then((res) => {
-        if ('data' in res) return setDistricts(res.data)
-        throw new Error(res.message[0])
-      })
-      .catch((err) => {
-        toast.error('Failed to fetch district data', {
-          description: err.message,
-          closeButton: true,
-        })
-      })
-  }, [query?.districts])
-
-  // Village data
-  useEffect(() => {
-    getData('villages', { ...query?.villages, sortBy: 'name' })
-      .then((res) => {
-        if ('data' in res) return setVillages(res.data)
-        throw new Error(res.message[0])
-      })
-      .catch((err) => {
-        toast.error('Failed to fetch village data', {
-          description: err.message,
-          closeButton: true,
-        })
-      })
-  }, [query?.villages])
 
   // Island data
   useEffect(() => {
@@ -200,10 +124,9 @@ export default function MapDashboard() {
         }}
       >
         <ComboboxArea
-          options={provinces}
-          label="Province"
-          placeholder="Search Province"
+          area="provinces"
           value={selected?.province}
+          query={provinceQuery}
           onSelect={(province) => {
             setSelected((current) => ({ ...current, province }))
             if (province.code === query?.regencies?.parentCode) return
@@ -215,10 +138,9 @@ export default function MapDashboard() {
         />
 
         <ComboboxArea
-          options={regencies}
-          label="Regency"
-          placeholder="Search Regency"
+          area="regencies"
           value={selected?.regency}
+          query={query?.regencies}
           onSelect={(regency) => {
             setSelected((current) => ({ ...current, regency }))
             if (regency.code === query?.districts?.parentCode) return
@@ -241,10 +163,9 @@ export default function MapDashboard() {
         />
 
         <ComboboxArea
-          options={districts}
-          label="District"
-          placeholder="Search District"
+          area="districts"
           value={selected?.district}
+          query={query?.districts}
           onSelect={(district) => {
             setSelected((current) => ({ ...current, district }))
             if (district.code === query?.villages?.parentCode) return
@@ -266,10 +187,9 @@ export default function MapDashboard() {
         />
 
         <ComboboxArea
-          options={villages}
-          label="Village"
-          placeholder="Search village"
+          area="villages"
           value={selected?.village}
+          query={query?.villages}
           onSelect={(village) => {
             setSelected((current) => ({ ...current, village }))
           }}

--- a/components/map-dashboard.tsx
+++ b/components/map-dashboard.tsx
@@ -24,6 +24,7 @@ import {
 } from './ui/resizable'
 import { Skeleton } from './ui/skeleton'
 import { debounce } from '@/lib/utils'
+import { toast } from 'sonner'
 
 const Map = dynamic(() => import('@/components/map'), {
   loading: () => <Skeleton className="h-full rounded-none" />,
@@ -84,10 +85,14 @@ export default function MapDashboard() {
   useEffect(() => {
     getData('provinces', { sortBy: 'name', limit: MAX_PAGE_SIZE })
       .then((res) => {
-        setProvinces(res.data)
+        if ('data' in res) return setProvinces(res.data)
+        throw new Error(res.message[0])
       })
       .catch((err) => {
-        console.log(err)
+        toast.error('Failed to fetch province data', {
+          description: err.message,
+          closeButton: true,
+        })
       })
   }, [])
 
@@ -95,10 +100,14 @@ export default function MapDashboard() {
   useEffect(() => {
     getData('regencies', { ...query?.regencies, sortBy: 'name' })
       .then((res) => {
-        setRegencies(res.data)
+        if ('data' in res) return setRegencies(res.data)
+        throw new Error(res.message[0])
       })
       .catch((err) => {
-        console.log(err)
+        toast.error('Failed to fetch regency data', {
+          description: err.message,
+          closeButton: true,
+        })
       })
   }, [query?.regencies])
 
@@ -106,10 +115,14 @@ export default function MapDashboard() {
   useEffect(() => {
     getData('districts', { ...query?.districts, sortBy: 'name' })
       .then((res) => {
-        setDistricts(res.data)
+        if ('data' in res) return setDistricts(res.data)
+        throw new Error(res.message[0])
       })
       .catch((err) => {
-        console.log(err)
+        toast.error('Failed to fetch district data', {
+          description: err.message,
+          closeButton: true,
+        })
       })
   }, [query?.districts])
 
@@ -117,10 +130,14 @@ export default function MapDashboard() {
   useEffect(() => {
     getData('villages', { ...query?.villages, sortBy: 'name' })
       .then((res) => {
-        setVillages(res.data)
+        if ('data' in res) return setVillages(res.data)
+        throw new Error(res.message[0])
       })
       .catch((err) => {
-        console.log(err)
+        toast.error('Failed to fetch village data', {
+          description: err.message,
+          closeButton: true,
+        })
       })
   }, [query?.villages])
 
@@ -135,11 +152,13 @@ export default function MapDashboard() {
         limit,
       })
 
-      setIslands((current) => [...current, ...res.data])
+      if ('data' in res) {
+        setIslands((current) => [...current, ...res.data])
 
-      if (res.meta.pagination.pages.next) {
-        await fetchIslandsRecursively(page + 1)
-        return
+        if (res.meta.pagination.pages.next) {
+          await fetchIslandsRecursively(page + 1)
+          return
+        }
       }
 
       setLoadingIslands(false)

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useTheme } from 'next-themes'
+import { Toaster as Sonner } from 'sonner'
+
+type ToasterProps = React.ComponentProps<typeof Sonner>
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = 'system' } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps['theme']}
+      className="toaster group"
+      toastOptions={{
+        classNames: {
+          toast:
+            'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
+          description: 'group-[.toast]:text-muted-foreground',
+          actionButton:
+            'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
+          cancelButton:
+            'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -91,10 +91,16 @@ type GetDataReturn<Area extends Areas> = {
   }
 }
 
+type GetDataReturnError = {
+  statusCode: number
+  message: string[]
+  error: string
+}
+
 export async function getData<Area extends Areas>(
   area: Area,
   query?: Query<Area>,
-): Promise<GetDataReturn<Area>> {
+): Promise<GetDataReturn<Area> | GetDataReturnError> {
   const url = new URL(`${baseUrl}/${area}`)
 
   if (query?.parentCode && area !== 'provinces') {
@@ -121,10 +127,6 @@ export async function getData<Area extends Areas>(
   }
 
   const res = await fetch(url)
-
-  if (!res.ok) {
-    throw new Error(`Failed to fetch ${area} data`)
-  }
 
   return await res.json()
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -25,3 +25,10 @@ export function debounce<T extends any[]>(
     }, delay)
   }
 }
+
+/**
+ * Set the first letter of string into upper-case.
+ */
+export function ucFirstStr(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react-dom": "^18.2.0",
         "react-leaflet": "^4.2.1",
         "react-resizable-panels": "^2.0.3",
+        "sonner": "^1.4.0",
         "tailwind-merge": "^2.2.1",
         "tailwindcss": "^3.4.1",
         "tailwindcss-animate": "^1.0.7",
@@ -5529,6 +5530,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.4.0.tgz",
+      "integrity": "sha512-nvkTsIuOmi9e5Wz5If8ldasJjZNVfwiXYijBi2dbijvTQnQppvMcXTFNxL/NUFWlI2yJ1JX7TREDsg+gYm9WyA==",
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.2.1",
     "react-resizable-panels": "^2.0.3",
+    "sonner": "^1.4.0",
     "tailwind-merge": "^2.2.1",
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

> Put `[x]` to check

- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [ ] I have included the necessary changes to the documentation.
- [ ] I have added tests to cover my changes.

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using `[x]`

- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

Currently, the API throws error when the response of data fetching does not successful (200 OK) and that error doesn't show up on the UI (only logged in console).

## What is the new behavior?

- The API now returns valid response (object, not throw error) even if the data fetching does not successful (200 OK).
- Use `toast` to show the error in the UI.
- Refactor the `ComboboxArea` and `MapDashboard`.

## Other information

None
