### PR TITLE
fix quotes `"` issue in `CommandItem` component

### DIFF
--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -113,13 +113,14 @@ CommandSeparator.displayName = CommandPrimitive.Separator.displayName
 const CommandItem = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
->(({ className, ...props }, ref) => (
+>(({ className, value, ...props }, ref) => (
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
       'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
+    value={value?.replaceAll('"', '\\"')}
     {...props}
   />
 ))


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

> Put `[x]` to check

- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [ ] I have added tests to cover my changes.

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using `[x]`

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] *..... (describe the other type)*

## What is the current behavior?

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: 
- https://github.com/pacocoursey/cmdk/issues/189
- https://github.com/pacocoursey/cmdk/issues/212

Error when the `value` of  `CommandItem` component contains quotes `"`.

`CommandItem` component is a Ref component from [`cmdk`](https://github.com/pacocoursey/cmdk)'s `Command.Item` component.

## What is the new behavior?

Escape all quotes `"` in `value` as a temporary fix.

## Other information

Revert this changes when the issues are closed (fixed), and upgrade the `cmdk` dependency.
