### PR TITLE
fix: resize the map when the sidebar panel is resized

### DIFF
--- a/components/map-dashboard.tsx
+++ b/components/map-dashboard.tsx
@@ -5,7 +5,7 @@ import { Query, getData } from '@/lib/data'
 import { Cross2Icon, ExternalLinkIcon, ReloadIcon } from '@radix-ui/react-icons'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
-import { useEffect, useLayoutEffect, useState } from 'react'
+import { forwardRef, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Button } from './ui/button'
 import {
   ResizableHandle,
@@ -27,7 +27,7 @@ import {
   parentArea,
 } from '@/lib/const'
 import { Switch } from './ui/switch'
-import { LatLngBounds } from 'leaflet'
+import { LatLngBounds, Map as LeafletMap } from 'leaflet'
 import { useMap } from 'react-leaflet'
 
 const Map = dynamic(() => import('@/components/map'), {
@@ -69,6 +69,18 @@ function MapFlyToBounds({ bounds }: { bounds: LatLngBounds }) {
   return null
 }
 
+const MapRefSetter = forwardRef<LeafletMap | null>((props, ref) => {
+  const map = useMap()
+
+  useEffect(() => {
+    if (map && ref && 'current' in ref) {
+      ref.current = map // Set the ref to the map instance
+    }
+  }, [map, ref])
+
+  return null
+})
+
 type Props = {
   defaultSelected?: Selected
 }
@@ -90,6 +102,7 @@ export default function MapDashboard({ defaultSelected }: Props) {
   const [panelDirection, setPanelDirection] = useState<
     'horizontal' | 'vertical'
   >('horizontal')
+  const mapRef = useRef<LeafletMap | null>(null)
 
   useEffect(() => {
     if (defaultSelected) {
@@ -160,6 +173,12 @@ export default function MapDashboard({ defaultSelected }: Props) {
 
     return () => window.removeEventListener('resize', handleResize)
   }, [])
+
+  const handleResizeMap = () => {
+    if (mapRef.current) {
+      mapRef.current.invalidateSize({ animate: true })
+    }
+  }
 
   return (
     <ResizablePanelGroup
@@ -342,9 +361,14 @@ export default function MapDashboard({ defaultSelected }: Props) {
 
       <ResizableHandle withHandle />
 
-      <ResizablePanel defaultSize={75}>
+      <ResizablePanel
+        defaultSize={75}
+        onResize={debounce(handleResizeMap, 100)}
+      >
         <Map className="h-full z-0">
           {areaBounds && <MapFlyToBounds bounds={areaBounds} />}
+
+          <MapRefSetter ref={mapRef} />
 
           {Object.entries(featureConfig).map(([area, config]) => {
             const selectedArea =

--- a/components/map-dashboard.tsx
+++ b/components/map-dashboard.tsx
@@ -80,6 +80,7 @@ const MapRefSetter = forwardRef<LeafletMap | null>((props, ref) => {
 
   return null
 })
+MapRefSetter.displayName = 'MapRefSetter'
 
 type Props = {
   defaultSelected?: Selected


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

> Put `[x]` to check

- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using `[x]`

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] *..... (describe the other type)*

## What is the current behavior?
When the sidebar panel is resized, the map does not resize accordingly.

## What is the new behavior?
Make the map resize dynamically to match the changes in the sidebar panel's size.

## Other information
None
