### PR TITLE
feat: double-click the sidebar panel to collapse/expand

### DIFF
--- a/components/map-dashboard.tsx
+++ b/components/map-dashboard.tsx
@@ -29,6 +29,7 @@ import {
 import { Switch } from './ui/switch'
 import { LatLngBounds, Map as LeafletMap } from 'leaflet'
 import { useMap } from 'react-leaflet'
+import { ImperativePanelHandle } from 'react-resizable-panels'
 
 const Map = dynamic(() => import('@/components/map'), {
   loading: () => <Skeleton className="h-full rounded-none" />,
@@ -103,7 +104,8 @@ export default function MapDashboard({ defaultSelected }: Props) {
   const [panelDirection, setPanelDirection] = useState<
     'horizontal' | 'vertical'
   >('horizontal')
-  const mapRef = useRef<LeafletMap | null>(null)
+  const mapRef = useRef<LeafletMap>(null)
+  const sidebarRef = useRef<ImperativePanelHandle>(null)
 
   useEffect(() => {
     if (defaultSelected) {
@@ -181,6 +183,15 @@ export default function MapDashboard({ defaultSelected }: Props) {
     }
   }
 
+  const handleSidebarToggle = () => {
+    const sidebar = sidebarRef.current
+    if (sidebar?.isCollapsed()) {
+      sidebar?.expand()
+    } else {
+      sidebar?.collapse()
+    }
+  }
+
   return (
     <ResizablePanelGroup
       direction={panelDirection}
@@ -191,6 +202,7 @@ export default function MapDashboard({ defaultSelected }: Props) {
         minSize={16}
         collapsible
         className="h-full"
+        ref={sidebarRef}
         style={{
           overflowY: 'auto',
         }}
@@ -360,7 +372,7 @@ export default function MapDashboard({ defaultSelected }: Props) {
         </div>
       </ResizablePanel>
 
-      <ResizableHandle withHandle />
+      <ResizableHandle withHandle onDoubleClick={handleSidebarToggle} />
 
       <ResizablePanel
         defaultSize={75}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

> Put `[x]` to check

- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using `[x]`

- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
Currently, users can only resize the sidebar by dragging it manually, which can be a bit frustrating.

## What is the new behavior?
Now, users can easily collapse or expand the sidebar by simply double-clicking the toggle.

## Other information
None
