### PR TITLE
refactor: use `NextResponse` instead of `Response`

### DIFF
--- a/app/api/[area]/[code]/boundary/route.ts
+++ b/app/api/[area]/[code]/boundary/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { Params, paramSchema } from './schema'
 import { getBoundaryData } from '@/lib/data'
@@ -11,12 +11,12 @@ export async function GET(
   try {
     validatedParams = paramSchema.parse(params)
   } catch (error) {
-    return new Response(
-      JSON.stringify({
+    return NextResponse.json(
+      {
         statusCode: 400,
         message: 'Bad Request',
         ...(error instanceof z.ZodError && { error: error.errors }),
-      }),
+      },
       { status: 400 },
     )
   }

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -4,6 +4,7 @@ import { get } from 'https'
 import { config } from './config'
 import { Areas, GetArea, parentArea, singletonArea } from './const'
 import { addDotSeparator } from './utils'
+import { NextResponse } from 'next/server'
 
 export type Query<Area extends Areas> = {
   limit?: number
@@ -94,7 +95,7 @@ export async function getSpecificData<Area extends Areas>(
 export async function getBoundaryData(area: Areas, code: string) {
   const url = `${config.dataSource.boundary.url}/${area}/${addDotSeparator(code.replaceAll('.', ''))}.geojson`
 
-  return new Promise<Response>((resolve, reject) => {
+  return new Promise<NextResponse>((resolve, reject) => {
     // Create encoding to convert token (string) to Uint8Array
     const encoder = new TextEncoder()
 
@@ -105,11 +106,11 @@ export async function getBoundaryData(area: Areas, code: string) {
     get(url, (res) => {
       if (res.statusCode !== 200) {
         resolve(
-          new Response(
-            JSON.stringify({
+          NextResponse.json(
+            {
               statusCode: res.statusCode,
               message: res.statusMessage,
-            }),
+            },
             { status: res.statusCode },
           ),
         )
@@ -121,7 +122,7 @@ export async function getBoundaryData(area: Areas, code: string) {
 
       res.on('end', () => {
         writer.close()
-        resolve(new Response(stream.readable, { status: res.statusCode }))
+        resolve(new NextResponse(stream.readable, { status: res.statusCode }))
       })
 
       res.on('error', (error) => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

> Put `[x]` to check

- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using `[x]`

- [ ] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
This pull request includes updates to handle responses more consistently by using `NextResponse` instead of `Response` across multiple files.

## What is the new behavior?
The main changes involve importing `NextResponse` and replacing instances of `Response` with `NextResponse`.

## Other information

None