### PR TITLE
Implement dark mode for leaflet components

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -57,3 +57,43 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* Override default leaflet styles */
+.leaflet-container {
+  /* Popup */
+  .leaflet-popup {
+    .leaflet-popup-content-wrapper {
+      @apply bg-popover text-popover-foreground;
+    }
+
+    .leaflet-popup-close-button {
+      @apply text-muted-foreground;
+    }
+
+    .leaflet-popup-close-button:hover {
+      @apply text-popover-foreground font-bold;
+    }
+
+    .leaflet-popup-tip {
+      @apply bg-popover;
+    }
+  }
+
+  /* Marker */
+  .leaflet-marker-icon {
+    span {
+      @apply text-black font-semibold;
+    }
+  }
+
+  /* Control */
+  .leaflet-control-container {
+    .leaflet-bar a {
+      @apply bg-card text-card-foreground;
+    }
+
+    .leaflet-control-attribution {
+      @apply bg-card text-card-foreground;
+    }
+  }
+}

--- a/components/map-dashboard.tsx
+++ b/components/map-dashboard.tsx
@@ -439,9 +439,7 @@ export default function MapDashboard({ defaultSelected }: Props) {
                   title={island.name}
                 >
                   <div className="flex flex-col gap-2">
-                    <b className="font-bold block text-primary">
-                      {island.name}
-                    </b>
+                    <b className="font-bold block">{island.name}</b>
 
                     <span className="text-xs text-gray-500 block">
                       {island.coordinate}
@@ -461,12 +459,12 @@ export default function MapDashboard({ defaultSelected }: Props) {
                     {(island.isPopulated || island.isOutermostSmall) && (
                       <div className="flex gap-1 mt-1">
                         {island.isPopulated && (
-                          <span className="bg-green-500 text-white font-medium rounded-full px-2 py-1">
+                          <span className="bg-green-500 text-popover font-semibold rounded-full px-2 py-1">
                             Populated
                           </span>
                         )}
                         {island.isOutermostSmall && (
-                          <span className="bg-red-500 text-white font-medium rounded-full px-2 py-1">
+                          <span className="bg-red-500 text-popover font-semibold rounded-full px-2 py-1">
                             Outermost Small Island
                           </span>
                         )}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

> Put `[x]` to check

- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using `[x]`

- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

Map components styles like popup and zoom control weren't changes when dark mode active. Some components like the number of the island marker also less visible in dark mode.

## What is the new behavior?
This pull request includes changes to the `app/globals.css` and `components/map-dashboard.tsx` files to improve the styling of map elements and update the text styling for better consistency.

Styling improvements:

* `app/globals.css`: Added custom styles to override default Leaflet styles, including popups, markers, and controls.

Text styling updates:

* [`components/map-dashboard.tsx`](diffhunk://#diff-d82551ae386e7e13f3e2f1be40a2731d700c0fcd78a646663b7f33141d30be94L442-R442): Removed the `text-primary` class from the island name to use the default text color.
* [`components/map-dashboard.tsx`](diffhunk://#diff-d82551ae386e7e13f3e2f1be40a2731d700c0fcd78a646663b7f33141d30be94L464-R467): Updated the text color of the "Populated" and "Outermost Small Island" labels to use `text-popover` and changed the font weight to `font-semibold`.

## Other information
None
