### PR TITLE
fix: not all provinces data loaded in `AreaSelectors`

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -12,6 +12,12 @@ export function getObjectKeys<T extends object>(obj: T): (keyof T)[] {
   return Object.keys(obj) as (keyof T)[]
 }
 
+export function objectFromEntries<K extends string | number | symbol, V>(
+  entries: [K, V][],
+): Record<K, V> {
+  return Object.fromEntries(entries) as Record<K, V>
+}
+
 export function getAreaRelations(area: Area) {
   return {
     parent: parentArea[area],

--- a/modules/MapDashboard/AreaSelectors.tsx
+++ b/modules/MapDashboard/AreaSelectors.tsx
@@ -37,7 +37,7 @@ export default function AreaSelectors() {
 
         if (parent && parent !== 'island' && selectedArea[parent]) {
           query = {
-            parentCode: selectedArea[parent].code,
+            parentCode: selectedArea[parent]?.code, // Need optional chaining. Build fails without it
             limit: MAX_PAGE_SIZE,
           }
         }

--- a/modules/MapDashboard/AreaSelectors.tsx
+++ b/modules/MapDashboard/AreaSelectors.tsx
@@ -2,7 +2,12 @@
 
 import { type FeatureArea, config, featureConfig } from '@/lib/config'
 import type { Query } from '@/lib/data'
-import { debounce, getAreaRelations, getObjectKeys } from '@/lib/utils'
+import {
+  debounce,
+  getAreaRelations,
+  getObjectKeys,
+  objectFromEntries,
+} from '@/lib/utils'
 import { useMemo, useState } from 'react'
 import ComboboxArea from './ComboboxArea'
 import { useMapDashboard } from './hooks/useDashboard'
@@ -11,12 +16,7 @@ const MAX_PAGE_SIZE = config.dataSource.area.pagination.maxPageSize
 
 export default function AreaSelectors() {
   const { isLoading, selectedArea, changeSelectedArea } = useMapDashboard()
-  const [query, setQuery] = useState<{ [A in FeatureArea]: Query<A> }>({
-    province: {},
-    regency: { parentCode: selectedArea.province?.code },
-    district: { parentCode: selectedArea.regency?.code },
-    village: { parentCode: selectedArea.district?.code },
-  })
+
   const areas = useMemo(
     () =>
       getObjectKeys(featureConfig).map((area) => ({
@@ -25,6 +25,29 @@ export default function AreaSelectors() {
       })),
     [],
   )
+
+  const defaultQuery = objectFromEntries(
+    areas.reduce<[FeatureArea, Query<FeatureArea>][]>(
+      (acc, { area, parent }) => {
+        if (parent !== 'island') {
+          acc.push([
+            area,
+            {
+              limit: MAX_PAGE_SIZE,
+              ...(parent && {
+                parentCode: selectedArea[parent]?.code,
+              }),
+            },
+          ])
+        }
+        return acc
+      },
+      [],
+    ),
+  )
+
+  const [query, setQuery] =
+    useState<{ [A in FeatureArea]: Query<A> }>(defaultQuery)
 
   return (
     <div className="flex flex-col gap-2 w-full">

--- a/modules/MapDashboard/AreaSelectors.tsx
+++ b/modules/MapDashboard/AreaSelectors.tsx
@@ -33,7 +33,9 @@ export default function AreaSelectors() {
           acc.push([
             area,
             {
-              limit: MAX_PAGE_SIZE,
+              ...(area === 'province' && {
+                limit: MAX_PAGE_SIZE,
+              }),
               ...(parent && {
                 parentCode: selectedArea[parent]?.code,
               }),

--- a/modules/MapDashboard/AreaSelectors.tsx
+++ b/modules/MapDashboard/AreaSelectors.tsx
@@ -29,19 +29,20 @@ export default function AreaSelectors() {
   const defaultQuery = objectFromEntries(
     areas.reduce<[FeatureArea, Query<FeatureArea>][]>(
       (acc, { area, parent }) => {
-        if (parent !== 'island') {
-          acc.push([
-            area,
-            {
-              ...(area === 'province' && {
-                limit: MAX_PAGE_SIZE,
-              }),
-              ...(parent && {
-                parentCode: selectedArea[parent]?.code,
-              }),
-            },
-          ])
+        let query: Query<typeof area> = {}
+
+        if (area === 'province') {
+          query = { limit: MAX_PAGE_SIZE }
         }
+
+        if (parent && parent !== 'island' && selectedArea[parent]) {
+          query = {
+            parentCode: selectedArea[parent].code,
+            limit: MAX_PAGE_SIZE,
+          }
+        }
+
+        acc.push([area, query])
         return acc
       },
       [],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

> Put `[x]` to check

- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using `[x]`

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

- Not all **provinces** are loaded in Provice selector (only load 10 provinces).

## What is the new behavior?
This pull request introduces a new utility function and refactors the `AreaSelectors` component to improve code readability and maintainability. The most important changes include adding the `objectFromEntries` function and refactoring the `query` state initialization in `AreaSelectors`.

### New Utility Function:

* [`lib/utils.ts`](diffhunk://#diff-98e56006aa8453a29bc2b8bc8e6f718b3f17ba66470f3a52a5dc5bd643482e70R15-R20): Added the `objectFromEntries` function to convert an array of key-value pairs into an object. (`[lib/utils.tsR15-R20](diffhunk://#diff-98e56006aa8453a29bc2b8bc8e6f718b3f17ba66470f3a52a5dc5bd643482e70R15-R20)`)

### Refactoring:

* [`modules/MapDashboard/AreaSelectors.tsx`](diffhunk://#diff-5b6caf9b06377fde132cc68d7700b2054f6f92ff966f11d60be387521e2b3babL5-R10): Updated imports to include the new `objectFromEntries` function. (`[modules/MapDashboard/AreaSelectors.tsxL5-R10](diffhunk://#diff-5b6caf9b06377fde132cc68d7700b2054f6f92ff966f11d60be387521e2b3babL5-R10)`)
* [`modules/MapDashboard/AreaSelectors.tsx`](diffhunk://#diff-5b6caf9b06377fde132cc68d7700b2054f6f92ff966f11d60be387521e2b3babR29-R53): Refactored the initialization of the `query` state to use the new `objectFromEntries` function, improving readability and reducing redundancy. (`[modules/MapDashboard/AreaSelectors.tsxR29-R53](diffhunk://#diff-5b6caf9b06377fde132cc68d7700b2054f6f92ff966f11d60be387521e2b3babR29-R53)`)

## Other information
None
