### PR TITLE
Simplify `AreaBoundary`, prevent unnecessary `useArea` usage

### DIFF
--- a/components/area-boundary.tsx
+++ b/components/area-boundary.tsx
@@ -1,9 +1,7 @@
 'use client'
 
-import { useArea } from '@/hooks/useArea'
 import useBoundary from '@/hooks/useBoundary'
 import { type FeatureArea, featureConfig } from '@/lib/config'
-import type { GetSpecificDataReturn } from '@/lib/data'
 import dynamic from 'next/dynamic'
 import { useEffect } from 'react'
 import type { GeoJSONProps } from 'react-leaflet'
@@ -36,12 +34,11 @@ const defaultOverlayPaneZIndex = 400
 
 export type AreaBoundaryProps<A extends FeatureArea> = Omit<
   GeoJSONProps,
-  'key' | 'data' | 'children' | 'pane'
+  'key' | 'data' | 'pane'
 > & {
   area: A
   code: string
   onLoading?: (isLoading: boolean) => void
-  render?: (data?: GetSpecificDataReturn<A>['data']) => React.ReactNode
 }
 
 export default function AreaBoundary<A extends FeatureArea>({
@@ -49,26 +46,16 @@ export default function AreaBoundary<A extends FeatureArea>({
   code,
   onLoading,
   pathOptions,
-  render,
   ...props
 }: AreaBoundaryProps<A>) {
   const { order, color } = featureConfig[area]
   const boundary = useBoundary(area, code)
-  const areaDetails = useArea(area, code)
 
   useEffect(() => {
     onLoading?.(boundary.status === 'pending')
   }, [boundary.status, onLoading])
 
   if (boundary.status === 'pending') {
-    return null
-  }
-
-  if (areaDetails.status === 'error') {
-    toast.error(`Failed to fetch ${area} data`, {
-      description: areaDetails.error.message,
-      closeButton: true,
-    })
     return null
   }
 
@@ -96,8 +83,6 @@ export default function AreaBoundary<A extends FeatureArea>({
             ...pathOptions,
           }}
         />
-
-        {render?.(areaDetails.data)}
       </FeatureGroup>
     </Pane>
   )

--- a/modules/MapDashboard/BoundaryLayers.tsx
+++ b/modules/MapDashboard/BoundaryLayers.tsx
@@ -42,10 +42,9 @@ export default function BoundaryLayers() {
                   fillOpacity: 0,
                 }),
               }}
-              render={(data) => (
-                <PopupArea area={area} data={data} latLng={latLng} />
-              )}
-            />
+            >
+              <PopupArea area={area} code={selected.code} latLng={latLng} />
+            </AreaBoundary>
           )
         }
       })}

--- a/modules/Pilkada2024/BoundaryLayers.tsx
+++ b/modules/Pilkada2024/BoundaryLayers.tsx
@@ -79,18 +79,17 @@ export default function BoundaryLayers({
                 }
               },
             }}
-            render={() => (
-              <Popup pane="popupPane">
-                <h1 className="font-bold mb-2">{_childArea.name}</h1>
-                <VotesChart
-                  votes={votes}
-                  candidates={candidates}
-                  hideLegend
-                  className="w-[240px]"
-                />
-              </Popup>
-            )}
-          />
+          >
+            <Popup pane="popupPane">
+              <h1 className="font-bold mb-2">{_childArea.name}</h1>
+              <VotesChart
+                votes={votes}
+                candidates={candidates}
+                hideLegend
+                className="w-[240px]"
+              />
+            </Popup>
+          </AreaBoundary>
         )
       })}
     </>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

> Put `[x]` to check

- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using `[x]`

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
`AreaBoundary` component use `useArea` hook to fetch the data and provide `render` property to render the children based on its data. But this behavior is unnecessary because in some cases, the data for the children has been fetched in somewhere else.

This behavior can leads to **Throttle Error: Too Many Request** since the [idn-area API](https://github.com/fityannugroho/idn-area) has request limits.

## What is the new behavior?
- Removing the `render` prop
- Directly using the `useArea` hook within components to fetch data.

**Key changes include:**

### Removal of `render` prop and direct use of `useArea` hook:

* [`components/area-boundary.tsx`](diffhunk://#diff-fcba0a1ff0012ded25e17ce602d7f4c5a28a8e4f19358658b2878df51ba36673L3-L6): Removed the `render` prop and the `useArea` hook call within the `AreaBoundary` component. Updated the component to handle boundary errors directly.

### Updates to components using `AreaBoundary`:

* [`modules/MapDashboard/BoundaryLayers.tsx`](diffhunk://#diff-06cca42e42fd3110d2b305257a48ebb481b5a410d7f36d1cb4f6b852198701f8L45-R47): Updated to remove the `render` prop and directly use the `PopupArea` component with the area code.

### Enhancements to `PopupArea` component:

* [`modules/MapDashboard/PopupArea.tsx`](diffhunk://#diff-669c255cb1e151c103551cbf7b7e2556fb8220580ce892417c025cc7d7e3d061R3-R9): Integrated the `useArea` hook directly within the `PopupArea` component. Added loading and error handling states to improve user feedback.

### Consistency improvements in other boundary layers:

* [`modules/Pilkada2024/BoundaryLayers.tsx`](diffhunk://#diff-29bb2b0c2a56d29873e88177c9c51fc907d32b50b3664cde121efb065dd2dc4dL82-R82): Removed the `render` prop and updated to use the `Popup` component directly within `AreaBoundary`.
