### PR TITLE
refactor: make `ComboboxArea` component reusable

### DIFF
--- a/modules/MapDashboard/AreaSelectors.tsx
+++ b/modules/MapDashboard/AreaSelectors.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import ComboboxArea from '@/components/ComboboxArea'
 import { type FeatureArea, config, featureConfig } from '@/lib/config'
 import type { Query } from '@/lib/data'
 import {
@@ -9,7 +10,6 @@ import {
   objectFromEntries,
 } from '@/lib/utils'
 import { useMemo, useState } from 'react'
-import ComboboxArea from './ComboboxArea'
 import { useMapDashboard } from './hooks/useDashboard'
 
 const MAX_PAGE_SIZE = config.dataSource.area.pagination.maxPageSize
@@ -60,6 +60,8 @@ export default function AreaSelectors() {
           area={area}
           query={query[area]}
           disabled={parent ? isLoading[parent] : false}
+          autoClose
+          fullWidth
           onSelect={(selected) => {
             changeSelectedArea(area, selected)
 

--- a/modules/Pilkada2024/Sidebar.tsx
+++ b/modules/Pilkada2024/Sidebar.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import ComboboxArea from '@/components/ComboboxArea'
 import { Combobox } from '@/components/combobox'
 import { Button } from '@/components/ui/button'
 import { config } from '@/lib/config'
@@ -8,7 +9,6 @@ import type { Query } from '@/lib/data'
 import { EraserIcon, LoaderCircleIcon } from 'lucide-react'
 import { useState } from 'react'
 import { toast } from 'sonner'
-import ComboboxArea from '../MapDashboard/ComboboxArea'
 import { useMapDashboard } from '../MapDashboard/hooks/useDashboard'
 import VotesChart from './VotesChart'
 import {
@@ -71,6 +71,8 @@ export default function Sidebar() {
         area={Area.PROVINCE}
         query={{ limit: config.dataSource.area.pagination.maxPageSize }}
         disabled={!election}
+        autoClose
+        fullWidth
         onSelect={(option) => {
           changeSelectedArea(Area.PROVINCE, option)
           setQuery((prevQuery) => ({
@@ -86,6 +88,8 @@ export default function Sidebar() {
           area={Area.REGENCY}
           query={regencyQuery}
           disabled={!selectedArea.province}
+          autoClose
+          fullWidth
           onSelect={(option) => {
             changeSelectedArea(Area.REGENCY, option)
           }}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [ ] I have included the necessary changes to the documentation.
- [ ] I have added tests to cover my changes.

## PR Type
What kind of change does this PR introduce?
- [ ] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
Currently `ComboboxArea` component depends to the `useMapDashboard` hook to handle the selected option, so that it must be implemented under `MapDashboardProvider` only.

## What is the new behavior?
- Untied `ComboboxArea` component dependence to the `useMapDashboard` hook. Replace it with inner `useState`.
- Apply `useMemo` to memoize the options.
- Remove properties override for `autoClose` and `fullWidth`. Now it must be set explicitly.
- Move `ComboboxArea.tsx` file to `components` directory.