### PR TITLE
fix: improve error handling in data fetching functions

### DIFF
--- a/hooks/useBoundary.ts
+++ b/hooks/useBoundary.ts
@@ -15,7 +15,7 @@ export default function useBoundary(area: Area, code: string) {
       throw new Error(
         res.statusCode === 404
           ? `Data not found for ${area} ${code}`
-          : `Unexpected status code: ${res.statusCode}`,
+          : res.message || `Unexpected status code: ${res.statusCode}`,
       )
     },
   })

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -95,7 +95,25 @@ export async function getData<A extends Area, P extends string | Query<A>>(
     url.searchParams.append('page', query.page.toString())
   }
 
-  const res = await fetch(url)
+  let res: Response
+  try {
+    res = await fetch(url)
+  } catch (error) {
+    return {
+      statusCode: 500,
+      message: `Unable to connect to the server at ${url.host}. Please check your network connection or verify that the server is reachable.`,
+      error: (error as Error).message,
+    }
+  }
+
+  if (!res.ok) {
+    const errorMessage = await res.text()
+    return {
+      statusCode: res.status,
+      message: `Failed to fetch data, ${errorMessage}`,
+      error: res.statusText,
+    }
+  }
 
   return await res.json()
 }
@@ -110,8 +128,20 @@ export async function getBoundaryData(
   area: Area,
   code: string,
 ): Promise<BoundaryResponse> {
-  const url = `${config.dataSource.boundary.url}/${endpoints[area]}/${addDotSeparator(code.replaceAll('.', ''))}.geojson`
-  const res = await fetch(url)
+  const url = new URL(
+    `${config.dataSource.boundary.url}/${endpoints[area]}/${addDotSeparator(code.replaceAll('.', ''))}.geojson`,
+  )
+
+  let res: Response
+  try {
+    res = await fetch(url)
+  } catch (error) {
+    return {
+      statusCode: 500,
+      message: `Unable to connect to the server at ${url.host}. Please check your network connection or verify that the server is reachable.`,
+      data: undefined,
+    }
+  }
 
   return {
     statusCode: res.status,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type
What kind of change does this PR introduce?
- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
`getData` and `getBoundaryData` server actions will throw 500 error when the servers that defined in `.env` (`DATA_SOURCE_URL` and `DATA_SOURCE_BOUNDARY_URL`) is unreachable/inactive.

## What is the new behavior?
This pull request improves error handling and network robustness in the `data` and `useBoundary` modules. The changes include adding more descriptive error messages, handling network connection failures, and ensuring consistent error responses.

### Enhancements to error handling:

* [`hooks/useBoundary.ts`](diffhunk://#diff-ba48582c490e5240af164d56213c949a271462ddedf14183c6bcdf4a9c43b3ceL18-R18): Updated the error message logic to include `res.message` if available, providing more specific error details when an unexpected status code is encountered.

* `lib/data.ts`:
  - [`getData`](diffhunk://#diff-830adab641349e25599c6e7564dba9460cd4e29541f5d1fa9a84e6ddd8d6fa62L98-R116): Added a `try-catch` block to handle network connection errors gracefully. If a connection fails, it now returns a structured error response with a `500` status code and a descriptive message. Additionally, improved error messaging for non-OK responses by including the response body text.
  - [`getBoundaryData`](diffhunk://#diff-830adab641349e25599c6e7564dba9460cd4e29541f5d1fa9a84e6ddd8d6fa62L113-R144): Similar to `getData`, added a `try-catch` block to handle network errors and return a structured error response with a `500` status code and a descriptive message. Changed the URL construction to use the `URL` class for better readability and maintainability.