### PR TITLE
fix: popup tip position and change the text color

### DIFF
--- a/modules/MapDashboard/PopupArea.tsx
+++ b/modules/MapDashboard/PopupArea.tsx
@@ -41,8 +41,8 @@ export default function PopupArea<Area extends FeatureArea>({
 
   if (status === 'pending') {
     return (
-      <BasePopupArea className="flex items-center justify-center">
-        <span className="block text-gray-500">Loading...</span>
+      <BasePopupArea>
+        <span className="block text-muted-foreground mx-auto">Loading...</span>
       </BasePopupArea>
     )
   }
@@ -67,7 +67,7 @@ export default function PopupArea<Area extends FeatureArea>({
 
         return (
           <div key={parent} className="mt-1">
-            <span className="text-xs text-gray-500">
+            <span className="text-xs text-muted-foreground">
               {ucFirstStr(parent)} :
             </span>
             <br />


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type
What kind of change does this PR introduce?
- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
The popup tip position is in center. See the picture below:
 
![Screenshot 2025-05-20 150525](https://github.com/user-attachments/assets/c42de350-f667-4a8d-b8f6-c39a5d0b4a32)

## What is the new behavior?
This pull request includes updates to the `PopupArea` component in `modules/MapDashboard/PopupArea.tsx` to improve the styling consistency by replacing the `text-gray-500` class with the `text-muted-foreground` class.

Styling updates:

* Updated the "Loading..." message inside `BasePopupArea` to use the `text-muted-foreground` class for consistent styling and added a `mx-auto` class for centering.
* Replaced the `text-gray-500` class with `text-muted-foreground` for parent labels in the popup to align with the updated design language.

![Screenshot 2025-05-20 150624](https://github.com/user-attachments/assets/9bddedfe-c18e-4404-a68d-7828a86ca9d5)
