### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,9 @@ name: Test and Build
 env:
   NEXT_PUBLIC_VERCEL_URL: http://localhost:3000
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/fityannugroho/idn-area-map/security/code-scanning/3](https://github.com/fityannugroho/idn-area-map/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Based on the workflow's actions, it only needs `contents: read` to check out the repository and install dependencies. No write permissions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
