### PR TITLE
refactor: remove addDotSeparator utility

### DIFF
--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test, vi } from 'vitest'
 import { Area } from '../const'
 import {
-  addDotSeparator,
   cn,
   debounce,
   determineAreaByCode,
@@ -73,21 +72,6 @@ describe('getAreaRelations', () => {
     const area = 'INVALID' as Area
     const result = getAreaRelations(area)
     expect(result).toEqual({ parent: undefined, child: undefined })
-  })
-})
-
-describe('addDotSeparator', () => {
-  test('should add dot separator to area code', () => {
-    expect(addDotSeparator('9603')).toBe('96.03')
-    expect(addDotSeparator('960301')).toBe('96.03.01')
-    expect(addDotSeparator('9603011001')).toBe('96.03.01.1001')
-    expect(addDotSeparator('123')).toBe('123')
-  })
-
-  test('should return input for invalid length', () => {
-    expect(addDotSeparator('')).toBe('')
-    expect(addDotSeparator('1')).toBe('1')
-    expect(addDotSeparator('12345')).toBe('12345')
   })
 })
 

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,6 +1,5 @@
 import { config } from './config'
 import { type Area, type GetArea, endpoints, parentArea } from './const'
-import { addDotSeparator } from './utils'
 
 export type Query<A extends Area> = {
   limit?: number
@@ -127,7 +126,7 @@ export async function getBoundaryData(
   code: string,
 ): Promise<BoundaryResponse> {
   const url = new URL(
-    `${config.dataSource.boundary.url}/${endpoints[area]}/${addDotSeparator(code.replaceAll('.', ''))}.geojson`,
+    `${config.dataSource.boundary.url}/${endpoints[area]}/${code}.geojson`,
   )
 
   let res: Response

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -25,24 +25,6 @@ export function getAreaRelations(area: Area) {
   }
 }
 
-/**
- * Add dot separator for the area code.
- * - 4 digits (e.g. 9603) becomes 5 digits (e.g. 96.03)
- * - 6 digits (e.g. 960301) becomes 8 digits (e.g. 96.03.01)
- * - 10 digits (e.g. 9603011001) becomes 12 digits (e.g. 96.03.01.1001)
- */
-export function addDotSeparator(code: string) {
-  const codeLength = code.length
-
-  if (codeLength === 4) return `${code.slice(0, 2)}.${code.slice(2)}`
-  if (codeLength === 6)
-    return `${code.slice(0, 2)}.${code.slice(2, 4)}.${code.slice(4)}`
-  if (codeLength === 10)
-    return `${code.slice(0, 2)}.${code.slice(2, 4)}.${code.slice(4, 6)}.${code.slice(6)}`
-
-  return code
-}
-
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }

--- a/modules/MapDashboard/PopupArea.tsx
+++ b/modules/MapDashboard/PopupArea.tsx
@@ -2,7 +2,7 @@
 
 import { useArea } from '@/hooks/useArea'
 import type { FeatureArea } from '@/lib/config'
-import { addDotSeparator, getAllParents, ucFirstStr } from '@/lib/utils'
+import { getAllParents, ucFirstStr } from '@/lib/utils'
 import { LinkIcon, MapIcon } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
@@ -58,7 +58,7 @@ export default function PopupArea<Area extends FeatureArea>({
   return (
     <BasePopupArea>
       <span className="block font-bold text-sm">{data.name}</span>
-      <span className="text-sm">{addDotSeparator(data.code)}</span>
+      <span className="text-sm">{data.code}</span>
 
       {getAllParents(area).map((parent) => {
         const parentData = data.parent?.[parent]
@@ -81,7 +81,7 @@ export default function PopupArea<Area extends FeatureArea>({
         onClick={() => {
           try {
             navigator.clipboard.writeText(
-              `${window.location.origin}/${addDotSeparator(data.code)}`,
+              `${window.location.origin}/${data.code}`,
             )
             toast.success('Link copied to clipboard', {
               duration: 3_000, // 3 seconds


### PR DESCRIPTION
## Summary
- remove addDotSeparator utility and its tests
- use pre-formatted codes when fetching boundary data and displaying popups

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a678cd372883289cdc0454eb8712bb