### PR TITLE
fix(islands): load islands that do not belong to any regency

### DIFF
--- a/lib/data.ts
+++ b/lib/data.ts
@@ -72,7 +72,8 @@ export async function getData<A extends Area, P extends string | Query<A>>(
   )
   const parent = parentArea[area]
 
-  if (query?.parentCode && parent) {
+  // Allow empty string on `parentCode` query
+  if (query?.parentCode != null && parent) {
     url.searchParams.append(`${parent}Code`, query.parentCode)
   }
 

--- a/modules/MapDashboard/IslandMarkers.tsx
+++ b/modules/MapDashboard/IslandMarkers.tsx
@@ -17,9 +17,8 @@ const MapMarker = dynamic(() => import('@/components/MapMarker'), {
 })
 
 export default function IslandMarkers() {
-  const { selectedArea, loading } = useMapDashboard()
-  const regencyCode = selectedArea.regency?.code
-  const { data: islands = [] } = useIslands(regencyCode)
+  const { loading } = useMapDashboard()
+  const { data: islands = [] } = useIslands()
 
   return (
     <MarkerClusterGroup

--- a/modules/MapDashboard/IslandsInfo.tsx
+++ b/modules/MapDashboard/IslandsInfo.tsx
@@ -6,13 +6,11 @@ import { useIslands } from './hooks/useIslands'
 
 export default function IslandsInfo() {
   const { selectedArea } = useMapDashboard()
-  const { isLoading, data: islands = [] } = useIslands(
-    selectedArea.regency?.code,
-  )
+  const { isLoading, data: islands = [] } = useIslands()
 
   return (
     <div className="w-full p-2 border rounded flex justify-center items-center text-center">
-      {selectedArea.regency ? (
+      {selectedArea.province || selectedArea.regency ? (
         <div className="flex flex-col w-full justify-center items-center">
           {isLoading ? (
             <div className="flex gap-2 justify-center items-center">
@@ -35,7 +33,7 @@ export default function IslandsInfo() {
         </div>
       ) : (
         <span className="text-sm text-gray-500">
-          Select a regency to see islands
+          Select a province or regency to see islands
         </span>
       )}
     </div>

--- a/modules/MapDashboard/hooks/__tests__/useIslands.test.tsx
+++ b/modules/MapDashboard/hooks/__tests__/useIslands.test.tsx
@@ -1,0 +1,189 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { mockData } from '@/app/api/__mocks__/const'
+import { Area, type Island, type Province, type Regency } from '@/lib/const'
+import type { DashboardContext } from '../useDashboard'
+
+// Mock modules first
+vi.mock('@/lib/data', () => ({ getData: vi.fn() }))
+vi.mock('../useDashboard', () => ({ useMapDashboard: vi.fn() }))
+
+// Import after mocking
+import { getData } from '@/lib/data'
+import { useMapDashboard } from '../useDashboard'
+import { useIslands } from '../useIslands'
+
+const mockGetData = vi.mocked(getData)
+const mockUseMapDashboard = vi.mocked(useMapDashboard)
+
+// Helper to create minimal DashboardContext
+const createMockDashboardContext = (
+  selectedArea: Partial<DashboardContext['selectedArea']> = {},
+): DashboardContext => ({
+  selectedArea,
+  changeSelectedArea: vi.fn(),
+  isLoading: {},
+  loading: vi.fn(),
+  boundaryVisibility: {},
+  showBoundary: vi.fn(),
+  areaBounds: undefined,
+  setAreaBounds: vi.fn(),
+  clear: vi.fn(),
+})
+
+// Test data with complete types
+const mockProvince: Province = { code: '11', name: 'Aceh' }
+const mockRegency: Regency = {
+  code: '11.01',
+  name: 'Kabupaten Aceh Selatan',
+  provinceCode: '11',
+}
+
+const mockRegencyIslands: Island[] = (mockData[Area.ISLAND] as Island[]).filter(
+  (i) => i.regencyCode === '11.01',
+)
+
+const mockProvinceIslands: Island[] = [
+  {
+    code: '11.00.40099',
+    coordinate: '00°00\'00.00" N 000°00\'00.00" E',
+    isOutermostSmall: false,
+    isPopulated: false,
+    name: 'Pulau Tanpa Kabupaten',
+    regencyCode: null,
+    latitude: 0,
+    longitude: 0,
+  },
+]
+
+const createSuccessResponse = (data: Island[]) => ({
+  statusCode: 200,
+  message: 'OK',
+  data,
+  meta: {
+    total: data.length,
+    pagination: {
+      total: data.length,
+      pages: { first: 1, last: 1, current: 1, previous: null, next: null },
+    },
+  },
+})
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+})
+
+const wrapper = ({ children }: React.PropsWithChildren) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+)
+
+describe('useIslands', () => {
+  beforeEach(() => {
+    queryClient.clear()
+    mockGetData.mockClear()
+    mockUseMapDashboard.mockClear()
+  })
+
+  test('returns empty array when no area selected', async () => {
+    mockUseMapDashboard.mockReturnValue(createMockDashboardContext({}))
+
+    const { result } = renderHook(() => useIslands(), { wrapper })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.data).toEqual([])
+    expect(mockGetData).not.toHaveBeenCalled()
+  })
+
+  test('loads islands for specific regency', async () => {
+    mockUseMapDashboard.mockReturnValue(
+      createMockDashboardContext({ regency: mockRegency }),
+    )
+    mockGetData.mockResolvedValue(createSuccessResponse(mockRegencyIslands))
+
+    const { result } = renderHook(() => useIslands(), { wrapper })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.data).toEqual(mockRegencyIslands)
+    expect(mockGetData).toHaveBeenCalledWith(Area.ISLAND, {
+      page: 1,
+      parentCode: '11.01',
+      limit: expect.any(Number),
+    })
+  })
+
+  test('loads province islands when province selected without regency', async () => {
+    mockUseMapDashboard.mockReturnValue(
+      createMockDashboardContext({ province: mockProvince }),
+    )
+    mockGetData.mockResolvedValue(createSuccessResponse(mockProvinceIslands))
+
+    const { result } = renderHook(() => useIslands(), { wrapper })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    // Should filter province islands by code prefix
+    expect(result.current.data).toEqual(mockProvinceIslands)
+    expect(mockGetData).toHaveBeenCalledWith(Area.ISLAND, {
+      page: 1,
+      parentCode: '',
+      limit: expect.any(Number),
+    })
+  })
+
+  test('merges province and regency islands correctly', async () => {
+    mockUseMapDashboard.mockReturnValue(
+      createMockDashboardContext({
+        province: mockProvince,
+        regency: mockRegency,
+      }),
+    )
+
+    // Mock both queries
+    mockGetData
+      .mockResolvedValueOnce(createSuccessResponse(mockProvinceIslands)) // without-regency query
+      .mockResolvedValueOnce(createSuccessResponse(mockRegencyIslands)) // regency query
+
+    const { result } = renderHook(() => useIslands(), { wrapper })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    // Should merge and deduplicate
+    const expectedLength =
+      mockProvinceIslands.length + mockRegencyIslands.length
+    expect(result.current.data).toHaveLength(expectedLength)
+  })
+
+  test('handles getData error gracefully', async () => {
+    mockUseMapDashboard.mockReturnValue(
+      createMockDashboardContext({ regency: mockRegency }),
+    )
+    mockGetData.mockRejectedValue(new Error('API Error'))
+
+    const { result } = renderHook(() => useIslands(), { wrapper })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.error).toBeTruthy()
+    expect(result.current.data).toEqual([])
+  })
+
+  test('refetch calls both queries', async () => {
+    mockUseMapDashboard.mockReturnValue(
+      createMockDashboardContext({
+        province: mockProvince,
+        regency: mockRegency,
+      }),
+    )
+    mockGetData.mockResolvedValue(createSuccessResponse([]))
+
+    const { result } = renderHook(() => useIslands(), { wrapper })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    mockGetData.mockClear()
+    result.current.refetch()
+
+    // Should trigger refetch for both queries
+    await waitFor(() => expect(mockGetData).toHaveBeenCalled())
+  })
+})

--- a/modules/MapDashboard/hooks/useIslands.ts
+++ b/modules/MapDashboard/hooks/useIslands.ts
@@ -1,7 +1,9 @@
 import { useQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
 import { config } from '@/lib/config'
 import { Area, type Island } from '@/lib/const'
 import { getData } from '@/lib/data'
+import { useMapDashboard } from './useDashboard'
 
 const MAX_PAGE_SIZE = config.dataSource.area.pagination.maxPageSize
 
@@ -29,10 +31,73 @@ async function fetchIslandsRecursively(
   return []
 }
 
-export function useIslands(regencyCode?: string) {
-  return useQuery({
-    queryKey: ['islands', { parentCode: regencyCode }],
-    queryFn: () => fetchIslandsRecursively(regencyCode as string),
+export function useIslands() {
+  const { selectedArea } = useMapDashboard()
+  const provinceCode = selectedArea.province?.code
+  const regencyCode = selectedArea.regency?.code
+
+  // Load all islands in a province that does not belong to any regency
+  // Fetch the full list of islands that don't belong to any regency once and
+  // cache it. We only enable this when a province is selected to avoid
+  // fetching unnecessarily on initial load. Different provinces will reuse
+  // the same cached list and we filter it locally instead of refetching.
+  const allNoRegencyQuery = useQuery<Island[], Error>({
+    queryKey: ['islands', 'without-regency'],
+    queryFn: () => fetchIslandsRecursively(''),
+    enabled: !!provinceCode,
+    // keep it fresh for a while so switching provinces won't trigger refetch
+    staleTime: 1000 * 60 * 60, // 1 hour
+  })
+
+  // derive province-level islands from the cached full list
+  const provinceIslands = useMemo(() => {
+    if (!provinceCode) return []
+    const all: Island[] = (allNoRegencyQuery.data as Island[]) ?? []
+    return all.filter((island: Island) =>
+      island.code.startsWith(`${provinceCode}.00`),
+    )
+  }, [allNoRegencyQuery.data, provinceCode])
+
+  // Load islands for a specific regency
+  const regencyQuery = useQuery<Island[], Error>({
+    queryKey: ['islands', 'regency', regencyCode],
+    queryFn: () =>
+      regencyCode ? fetchIslandsRecursively(regencyCode) : Promise.resolve([]),
     enabled: !!regencyCode,
   })
+
+  // Compute aggregated islands from province + regency query results
+  const islands = useMemo(() => {
+    const prov = provinceIslands ?? []
+    const reg = regencyQuery.data ?? []
+    const map = new Map<string, Island>()
+
+    // add province islands first
+    prov.forEach((i) => {
+      map.set(i.code, i)
+    })
+    // overlay regency islands (will replace duplicates)
+    reg.forEach((i) => {
+      map.set(i.code, i)
+    })
+
+    return Array.from(map.values())
+  }, [provinceIslands, regencyQuery.data])
+
+  const isLoading = allNoRegencyQuery.isLoading || regencyQuery.isLoading
+  const isFetching = allNoRegencyQuery.isFetching || regencyQuery.isFetching
+  const aggregatedError = [regencyQuery.error, allNoRegencyQuery.error].filter(
+    Boolean,
+  )
+
+  return {
+    data: islands,
+    isLoading,
+    isFetching,
+    error: aggregatedError.length > 0 ? aggregatedError : null,
+    refetch: () => {
+      void allNoRegencyQuery.refetch()
+      void regencyQuery.refetch()
+    },
+  }
 }


### PR DESCRIPTION
## Summary

Ensure islands that are not assigned to any regency are loaded and displayed on the map. Also improve island marker rendering, clustering behavior, and popup content to make islands more discoverable and metadata more accurate.

## What changed

- Fix loading logic so islands without a matching regency are included in the dataset and map layer.
- Improve island marker styling and clustering so markers remain visible and clustered sensibly across zoom levels.
- Fix popup / IslandsInfo content to show correct island metadata and clearer labels.
- Minor code cleanup and linting on island-related components.

## Files / components touched (high level)

- modules/MapDashboard/IslandMarkers.tsx
- modules/MapDashboard/IslandsInfo.tsx
- modules/MapDashboard/MapView.tsx
- components/MapMarkerClusterGroup.tsx