### PR TITLE
fix: initialize `ComboboxArea` with default selected area

### DIFF
--- a/components/ComboboxArea.tsx
+++ b/components/ComboboxArea.tsx
@@ -26,17 +26,21 @@ export type ComboboxAreaProps<A extends FeatureArea> = Omit<
   'options' | 'onSelect' | 'selected'
 > & {
   area: A
+  defaultSelected?: GetArea<A>
   query: Query<A>
   onSelect?: (option: GetArea<A>) => void
 }
 
 export default function ComboboxArea<A extends FeatureArea>({
   area,
+  defaultSelected,
   query,
   onSelect,
   ...comboboxProps
 }: ComboboxAreaProps<A>) {
-  const [selectedArea, setSelectedArea] = useState<GetArea<A> | undefined>()
+  const [selectedArea, setSelectedArea] = useState<GetArea<A> | undefined>(
+    defaultSelected,
+  )
   const { data: areas = [], error } = useArea(area, {
     ...query,
     sortBy: 'name',

--- a/modules/MapDashboard/AreaSelectors.tsx
+++ b/modules/MapDashboard/AreaSelectors.tsx
@@ -58,6 +58,7 @@ export default function AreaSelectors() {
         <ComboboxArea
           key={area}
           area={area}
+          defaultSelected={selectedArea[area]}
           query={query[area]}
           disabled={parent ? isLoading[parent] : false}
           autoClose


### PR DESCRIPTION
## Summary
This PR fixes the area selector behavior by passing the currently selected area into the Combobox on mount.

## Changes
- components/ComboboxArea.tsx: add `defaultSelected` prop and initialize internal `selectedArea` state from it.
- modules/MapDashboard/AreaSelectors.tsx: pass `selectedArea[area]` as `defaultSelected` to `ComboboxArea`.

## Why
Previously the combobox did not reflect the existing selection when the selector UI mounted. This ensures the UI shows the current selection immediately.

## How to test
1. Open the map dashboard and verify the area comboboxes display the currently selected area.
2. Select a different area and ensure linked child selectors update.

Checklist:
- [x] Pass current selected area to ComboboxArea
- [x] Initialize ComboboxArea internal state from prop
- [x] Verified changes are minimal and localized
