### PR TITLE
feat: add umami analytics integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,7 @@ NEXT_PUBLIC_DATA_SOURCE_PAGINATION_DEFAULT_PAGE_SIZE=10
 # Get one at https://account.mapbox.com/access-tokens/
 # If not set, the default static OG image will be used.
 MAPBOX_ACCESS_TOKEN=
+
+# (Optional) Umami Analytics
+UMAMI_WEBSITE_ID=
+UMAMI_SCRIPT_URL=https://cloud.umami.is/script.js

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { config } from '@/lib/config'
 import { cn } from '@/lib/utils'
 import './globals.css'
 import type { Metadata } from 'next'
+import Script from 'next/script'
 import { ThemeProvider } from 'next-themes'
 import QueryProvider from '@/components/QueryProvider'
 import { Toaster } from '@/components/ui/sonner'
@@ -71,6 +72,13 @@ export default function RootLayout({
             <QueryProvider>{children}</QueryProvider>
             <Toaster />
           </ThemeProvider>
+          {config.umami.websiteId && (
+            <Script
+              src={config.umami.scriptUrl}
+              data-website-id={config.umami.websiteId}
+              strategy="lazyOnload"
+            />
+          )}
         </body>
       </html>
     </StrictMode>

--- a/lib/__tests__/config.test.ts
+++ b/lib/__tests__/config.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+describe('config', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    vi.resetModules()
+    process.env = { ...originalEnv }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  test('should load umami config from environment variables', async () => {
+    process.env.UMAMI_WEBSITE_ID = 'test-id'
+    process.env.UMAMI_SCRIPT_URL = 'https://custom.umami/script.js'
+
+    const { config } = await import('../config')
+    expect(config.umami.websiteId).toBe('test-id')
+    expect(config.umami.scriptUrl).toBe('https://custom.umami/script.js')
+  })
+
+  test('should use default scriptUrl if not provided', async () => {
+    process.env.UMAMI_WEBSITE_ID = 'test-id'
+    delete process.env.UMAMI_SCRIPT_URL
+
+    const { config } = await import('../config')
+    expect(config.umami.websiteId).toBe('test-id')
+    expect(config.umami.scriptUrl).toBe('https://cloud.umami.is/script.js')
+  })
+})

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -19,6 +19,10 @@ export type Config = Readonly<{
   mapbox: {
     accessToken: string | undefined
   }
+  umami: {
+    websiteId: string | undefined
+    scriptUrl: string
+  }
 }>
 
 export const config: Config = {
@@ -54,6 +58,11 @@ export const config: Config = {
   },
   mapbox: {
     accessToken: process.env.MAPBOX_ACCESS_TOKEN,
+  },
+  umami: {
+    websiteId: process.env.UMAMI_WEBSITE_ID,
+    scriptUrl:
+      process.env.UMAMI_SCRIPT_URL || 'https://cloud.umami.is/script.js',
   },
 } as const
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
> Put `[x]` to check
- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type
What kind of change does this PR introduce?
> Please check any kind of changes that applies to this PR using `[x]`
- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] *..... (describe the other type)*

## What is the current behavior?
> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

Currently, the application does not have any built-in analytics integration.

## What is the new behavior?
This PR adds integration for Umami analytics.
- It is disabled by default and can be enabled by setting the `UMAMI_WEBSITE_ID` environment variable.
- Uses `next/script` with the `lazyOnload` strategy to ensure it does not impact initial page load performance.
- Configurable via environment variables (website ID and script URL).

## Other information
Environment variables added:
- `UMAMI_WEBSITE_ID`: The Website ID from Umami dashboard.
- `UMAMI_SCRIPT_URL`: URL to the Umami script (defaults to `https://cloud.umami.is/script.js`).

See `.env.example` for details.