### PR TITLE
fix(Pilkada2024): correct chart legend labels under recharts v3

### DIFF
--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -287,7 +287,7 @@ function ChartLegendContent({
       )}
     >
       {payload.map((item) => {
-        const key = `${nameKey || item.dataKey || 'value'}`
+        const key = `${nameKey || item.value || item.dataKey || 'value'}`
         const itemConfig = getPayloadConfigFromPayload(config, item, key)
 
         return (

--- a/modules/Pilkada2024/VotesChart.legend.test.tsx
+++ b/modules/Pilkada2024/VotesChart.legend.test.tsx
@@ -1,0 +1,76 @@
+import { render } from '@testing-library/react'
+import { describe, expect, test, vi } from 'vitest'
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartLegendContent,
+} from '@/components/ui/chart'
+
+vi.mock('recharts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('recharts')>()
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children?: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+  }
+})
+
+const chartConfig = {
+  votes: { label: 'Votes' },
+  candidate1: { label: 'Paslon Satu' },
+  candidate2: { label: 'Paslon Dua' },
+  total: { label: 'Polling Stations Progress' },
+  finished: { label: 'Finished (75%)' },
+  notFinished: { label: 'Still Counting (25%)' },
+} satisfies ChartConfig
+
+// Mirrors the recharts v3 LegendPayload items produced by VotesChart:
+// the votes Pie (dataKey="votes", nameKey="candidate") and the polling
+// stations progress Pie (dataKey="total", nameKey="status").
+const mockPayload = [
+  {
+    value: 'candidate1',
+    dataKey: 'votes',
+    payload: { candidate: 'candidate1', votes: 100 },
+    color: '#f00',
+  },
+  {
+    value: 'candidate2',
+    dataKey: 'votes',
+    payload: { candidate: 'candidate2', votes: 50 },
+    color: '#00f',
+  },
+  {
+    value: 'finished',
+    dataKey: 'total',
+    payload: { status: 'finished', total: 150 },
+    color: '#0f0',
+  },
+  {
+    value: 'notFinished',
+    dataKey: 'total',
+    payload: { status: 'notFinished', total: 50 },
+    color: '#888',
+  },
+]
+
+describe('ChartLegendContent (VotesChart legend)', () => {
+  test('renders candidate names and polling station statuses', () => {
+    const { container } = render(
+      <ChartContainer config={chartConfig}>
+        <ChartLegendContent payload={mockPayload} />
+      </ChartContainer>,
+    )
+
+    const items = container.querySelectorAll('.gap-2 > div')
+    const labels = Array.from(items).map((item) => item.textContent)
+
+    expect(labels).toEqual([
+      'Paslon Satu',
+      'Paslon Dua',
+      'Finished (75%)',
+      'Still Counting (25%)',
+    ])
+  })
+})


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
> Put `[x]` to check
- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [ ] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type
What kind of change does this PR introduce?
> Please check any kind of changes that applies to this PR using `[x]`
- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] *..... (describe the other type)*

## What is the current behavior?
> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

The sidebar chart legend on `/pilkada2024` showed generic labels (`"Votes"` / `"Polling Stations Progress"` repeated) instead of the actual data labels (candidate names, polling-station statuses).

## What is the new behavior?
The sidebar chart legend now correctly displays candidate names (`"Paslon Satu"`, `"Paslon Dua"`, …) and polling-station statuses (`"Finished (75%)"`, `"Still Counting (25%)"`), matching the config-defined labels.

**Fix (one line in `components/ui/chart.tsx`, `ChartLegendContent`):** prefer the entry name in key resolution:

```
`${nameKey || item.value || item.dataKey || 'value'}`
```

## Other information

**Root cause:** `ChartLegendContent` resolved the legend config key as `` `${nameKey || item.dataKey || 'value'}` ``. Under recharts v3, each `LegendPayload` item carries `dataKey` (here `'votes'` / `'total'`), so every entry mapped to `config['votes'].label` / `config['total'].label` — producing the 4 wrong labels. The entry name lives in `item.value` (`'candidate1'`, `'finished'`, …), which v2-era code relied on when `dataKey` was absent.

**Broader diagnosis (recharts v3 audit):**
- `components/ui/chart.tsx` is the only recharts consumer in the repo (used solely by `VotesChart.tsx`) — breakage contained to Pilkada.
- The Pie `label` callback's `payload` field is preserved in v3 (`PieSectorData`), so the percentage labels are unaffected.
- `ChartTooltipContent` uses `item.name` (not `dataKey`) — unaffected.
- Conclusion: the legend was the only user-visible v3 breakage.

**Changes:** one line in `components/ui/chart.tsx` (line ~290) + new regression test `modules/Pilkada2024/VotesChart.legend.test.tsx`.

**Test:** The regression test renders `ChartLegendContent` with a payload mirroring recharts v3 `LegendPayload`; **fails before** the fix (showing exactly the production symptom) and **passes after**.

- `pnpm lint` ✅ clean (96 files)
- `pnpm test` ✅ 58 passed (+1 todo)
- `pnpm build` ✅

Surfaced by the recharts `^3.8.1 → ^3.10.1` bump in #106 (no chart code changed there).

